### PR TITLE
Fix outdated apt cache issues

### DIFF
--- a/tasks/arm.yml
+++ b/tasks/arm.yml
@@ -2,6 +2,7 @@
 ---
 - name: Install prerequirements
   ansible.builtin.apt:
+    update_cache: true
     name:
     # - add-apt-key
     - ca-certificates

--- a/tasks/debian.yml
+++ b/tasks/debian.yml
@@ -2,6 +2,7 @@
 ---
 - name: Install prerequirements
   ansible.builtin.apt:
+    update_cache: true
     name:
     # - add-apt-key
     - ca-certificates

--- a/tasks/ubuntu.yml
+++ b/tasks/ubuntu.yml
@@ -2,6 +2,7 @@
 ---
 - name: Install prerequirements
   ansible.builtin.apt:
+    update_cache: true
     name:
     - add-apt-key
     - ca-certificates


### PR DESCRIPTION
Hey,

I had failures due to removing apt update commands and relying on the postgres role. However the very first apt install commands are run without update_cache and failed. This should solve this kind of problems for all distros using apt.