### PR TITLE
Fix ansible-postgresql/issues/6 and support Red Hat 9

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,13 @@
 # ansible-postgresql 2.3.2
 
-Ansible role to install postgresql server on Centos/Redhat 7 - 8 , Ubuntu 18-22, Debian 10-11
+Ansible role to install postgresql server on Centos/Redhat 7 - 9 , Ubuntu 18-22, Debian 10-11
 
 ## Tested:
 - Centos7
 - Centos8
 - Red Hat 8.7
 - Red Hat 8.8
+- Red Hat 9.0
 - Ubuntu18
 - Ubuntu20
 - Ubuntu22
@@ -522,6 +523,9 @@ replication
 ```
 
 ## Release notes
+
+upcoming
+- Use `python3-psycopg2` / `python3-cryptography` for all Red Hat distributions with Python 3, i.e. not `python38-psycopg2` / `python38-cryptography` for Python > 3.8 anymore.
 
 2.3.2
 - Skip pg_repack for Red Hat 8.8 (not possible anymore)

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -67,7 +67,7 @@
 - name: Import a key from a url
   ansible.builtin.rpm_key:
     state: present
-    key: https://download.postgresql.org/pub/repos/yum/RPM-GPG-KEY-PGDG
+    key: https://download.postgresql.org/pub/repos/yum/keys/PGDG-RPM-GPG-KEY-RHEL
 
 - name: Install repo for PostgreSQL
   ansible.builtin.package:

--- a/tasks/redhat.yml
+++ b/tasks/redhat.yml
@@ -100,21 +100,28 @@
   when: postgresql_version is version('14', '<') and ansible_distribution_version is version('8.8', '<')
 
 # posgres_db modul - Failed to import the required Python library (psycopg2)
+- name: Install python module for Postgres Redhat 9+
+  ansible.builtin.package:
+    name:
+      - "{% if ansible_python_version is version('3', '<') %}python2-psycopg2{% else \
+          %}python3-psycopg2{% endif %}"
+    state: present
+  when: ansible_distribution_major_version is version('8', '>=')
+
+# posgres_db modul - Failed to import the required Python library (psycopg2)
 - name: Install python module for Postgres Redhat 8+
   ansible.builtin.package:
     name:
-      - "{% if ansible_python_version is version('3', '<') %}python2-psycopg2{% elif \
-          ansible_python_version is version('3.8', '<') %}python3-psycopg2{% else \
-          %}python38-psycopg2{% endif %}"
+      - "{% if ansible_python_version is version('3', '<') %}python2-psycopg2{% else \
+          %}python3-psycopg2{% endif %}"
     state: present
   when: ansible_distribution_major_version is version('8', '>=')
 
 - name: Install python module for Postgres Redhat 7
   ansible.builtin.package:
     name:
-      - "{% if ansible_python_version is version('3', '<') %}python-psycopg2{% elif \
-          ansible_python_version is version('3.8', '<') %}python3-psycopg2{% else \
-          %}python38-psycopg2{% endif %}"
+      - "{% if ansible_python_version is version('3', '<') %}python-psycopg2{% else \
+          %}python3-psycopg2{% endif %}"
     state: present
   when: ansible_distribution_major_version is version('8', '<')
 

--- a/tasks/ssl_cert.yml
+++ b/tasks/ssl_cert.yml
@@ -51,12 +51,10 @@
 #    - ansible_os_family == 'RedHat'
 #    - ansible_distribution_major_version is version('8', '<')
 
-- name: Insall cryptography modul for ansible (Python 2.7-3.7-3.8)
+- name: Install cryptography modul for ansible (Python 2.7-3.x)
   ansible.builtin.package:
-    name: "{% if ansible_python_version is version('3', '<') %}python2-cryptography{% elif \
-    ansible_python_version is version('3.8', '<') %}python3-cryptography{% elif \
-    ansible_os_family == 'RedHat' and ansible_python_version is version('3.8', '>=') \
-    %}python38-cryptography{% else %}python3-cryptography{% endif %}"
+    name: "{% if ansible_python_version is version('3', '<') %}python2-cryptography{% else \
+    %}python3-cryptography{% endif %}"
     state: present
   when:
     - not external_crt.stat.exists or ( postgresql_ssl_dh is defined )


### PR DESCRIPTION
Use `python3-psycopg2` / `python3-cryptography` for all Red Hat distributions with Python 3, i.e. not `python38-psycopg2` / `python38-cryptography` for Python > 3.8 anymore.